### PR TITLE
latest doctest contains 'ERROR:' in case of error

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -45,6 +45,7 @@ var (
 		"marking it as not failed":      PASS,
 		"FATAL ERROR!":                  FAIL,
 		"ERROR!":                        FAIL,
+		"ERROR:":                        FAIL,
 		"TEST CASE FAILED!":             FAIL,
 		"Marking it as failed!":         FAIL,
 		"marking it as failed!":         FAIL,


### PR DESCRIPTION
```(bash)
[doctest] doctest version is "2.4.8"
[doctest] run with "--help" for options
===============================================================================
tests/tests.cpp:7:
TEST SUITE: producer_consumer
TEST CASE:  just_example
tests/tests.cpp:8: ERROR: CHECK( 5 == 4 ) is NOT correct!
  values: CHECK( 5 == 4 )
0.000162 s: just_example
===============================================================================
tests/tests.cpp:11:
TEST SUITE: producer_consumer
TEST CASE:  just_example1
tests/tests.cpp:12: SUCCESS: CHECK( 4 == 4 ) is correct!
  values: CHECK( 4 == 4 )
0.000029 s: just_example1
===============================================================================
[doctest] test cases: 2 | 1 passed | 1 failed | 0 skipped
[doctest] assertions: 2 | 1 passed | 1 failed |
[doctest] Status: FAILURE!
```